### PR TITLE
Fixes Lava Crystal causing a crash when attempting to place fire when…

### DIFF
--- a/src/main/java/WayofTime/bloodmagic/item/ItemLavaCrystal.java
+++ b/src/main/java/WayofTime/bloodmagic/item/ItemLavaCrystal.java
@@ -88,10 +88,15 @@ public class ItemLavaCrystal extends ItemBindableBase implements IVariantProvide
         pos = pos.offset(facing);
         ItemStack itemstack = player.getHeldItem(hand);
 
+        Binding binding = getBinding(player.getHeldItem(hand));
+        
+        if (binding == null)
+            return EnumActionResult.FAIL;
+        
         if (!player.canPlayerEdit(pos, facing, itemstack))
             return EnumActionResult.FAIL;
 
-        if (worldIn.isAirBlock(pos) && NetworkHelper.getSoulNetwork(getBinding(player.getHeldItem(hand))).syphonAndDamage(player, SoulTicket.item(player.getHeldItem(hand), 100)).isSuccess()) {
+        if (worldIn.isAirBlock(pos) && NetworkHelper.getSoulNetwork(binding).syphonAndDamage(player, SoulTicket.item(player.getHeldItem(hand), 100)).isSuccess()) {
             worldIn.playSound(player, pos, SoundEvents.ITEM_FIRECHARGE_USE, SoundCategory.BLOCKS, 1.0F, itemRand.nextFloat() * 0.4F + 0.8F);
             worldIn.setBlockState(pos, Blocks.FIRE.getDefaultState(), 11);
         } else


### PR DESCRIPTION
… it is unbound. (#1663)

* Fixes Lava Crystal causing a crash when attempting to place fire when it is unbound.

* Update ItemLavaCrystal.java